### PR TITLE
Move to PVHVM 14.04 image

### DIFF
--- a/templates/rpc-ha-full-ceph.yml
+++ b/templates/rpc-ha-full-ceph.yml
@@ -588,7 +588,7 @@ resources:
           params:
             "%heat_stack_prefix%": { "Fn::Select": [ "0", { "Fn::Split" : [ "-", { get_param: "OS::stack_id" } ] } ] }
       flavor: { get_param: "infra_flavor" }
-      image: Ubuntu 14.04 LTS (Trusty Tahr) (PV)
+      image: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
       diskConfig: AUTO
       block_device_mapping:
         - device_name: /dev/xvdz


### PR DESCRIPTION
The Rax public cloud 14.04 PV image is missing the vhost_net module
which is required by OSA. vhost_net is not a new requirement, so this
problem may have been caused by an update to the 14.04 PV image.

This commit switches to using the Rax Pub
cloud PVHVM 14.04 image for heat multinode builds.

Connects rcbops/u-suk-dev#273
